### PR TITLE
Adjust arguments to term.Entrypoint

### DIFF
--- a/cmd/cgoase/main.go
+++ b/cmd/cgoase/main.go
@@ -57,7 +57,7 @@ func doMain() error {
 	}
 	defer db.Close()
 
-	return term.Entrypoint(db)
+	return term.Entrypoint(db, flags.Args())
 }
 
 func handleMessage(msg ase.Message) {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ module github.com/SAP/cgo-ase
 go 1.15
 
 require (
-	github.com/SAP/go-dblib v0.0.0-20210114120425-3f210eb9fa26
+	github.com/SAP/go-dblib v0.0.0-20210215075453-57f65d7cdfe6
 	github.com/spf13/pflag v0.0.0-20170417173400-9e4c21054fa1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2021 SAP SE
 #
 # SPDX-License-Identifier: Apache-2.0
-github.com/SAP/go-dblib v0.0.0-20210114120425-3f210eb9fa26 h1:QZRogGKckagKy7xhrUCgN++fBzWN1gXb5+Dj7eU7Y+c=
-github.com/SAP/go-dblib v0.0.0-20210114120425-3f210eb9fa26/go.mod h1:+J5fa7eSdQ3ig2CqOarENCW3L2vPdDF+hl0N5h5pXOU=
+github.com/SAP/go-dblib v0.0.0-20210215075453-57f65d7cdfe6 h1:4Fw0Cqyrl5xD98L+0lSdqZfPWnR09kQGx2wE6V0S3SY=
+github.com/SAP/go-dblib v0.0.0-20210215075453-57f65d7cdfe6/go.mod h1:+J5fa7eSdQ3ig2CqOarENCW3L2vPdDF+hl0N5h5pXOU=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Since this commit https://github.com/SAP/go-dblib/commit/7c44d78624926bd0d55549b559afa0028b82f0ed `term.Entrypoint` expects two arguments. However, these changes were not adjusted in `cmd/cgoase/main.go`.
Additionally, `go.mod` and `go.sum` were updated to the present `go-dblib` version.

**Tests**

- [x] make integration (However, this test is obsolete in this case since it's using environment variables^^)
