### PR TITLE
Adjust cgo-ase execution description

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ CGO_LDFLAGS="-L/path/to/OCS/lib" go build -o cgoase ./cmd/cgoase/
 ### Execution
 
 ```sh
-LD_LIBRARY_PATH="/path/to/OCS/lib" ./cgoase
+LD_LIBRARY_PATH="/path/to/OCS/lib:/path/to/OCS/lib3p:/path/to/OCS/lib3p64:" ./cgoase
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ CGO_LDFLAGS="-L/path/to/OCS/lib" go build -o cgoase ./cmd/cgoase/
 LD_LIBRARY_PATH="/path/to/OCS/lib:/path/to/OCS/lib3p:/path/to/OCS/lib3p64:" ./cgoase
 ```
 
+While `/path/to/OCS/lib` contains the libraries of the Open Client, `/path/to/OCS/lib3p`
+and `/path/to/OCS/lib3p64` contain the libraries needed to use ASE user store keys.
+
 ### Examples
 
 More examples can be found in the folder `examples`.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Adjust the `LD_LIBRARY_PATH` to the respective libraries.

**Related issues**

Closes #15 

**Tests**

- [ ] make integration (Not necessary)
