### PR TITLE
Add AppName property

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ func main() {
 
 ### Properties
 
+##### AppName / app-name
+
+Recognized values: string
+
+When set overrides Client-Libraries default application name sent to the
+ASE server.
 
 ##### Userstorekey / userstorekey
 

--- a/connection.go
+++ b/connection.go
@@ -122,6 +122,15 @@ func NewConnection(driverCtx *csContext, info *Info) (*Connection, error) {
 		}
 	}
 
+	if info.AppName != "" {
+		ptrAppName := unsafe.Pointer(C.CString(info.AppName))
+		defer C.free(ptrAppName)
+
+		if retval := C.ct_con_props(conn.conn, C.CS_SET, C.CS_APPNAME, ptrAppName, C.CS_NULLTERM, nil); retval != C.CS_SUCCEED {
+			return nil, makeError(retval, "C.ct_con_props failed for CS_APPNAME")
+		}
+	}
+
 	if retval := C.ct_connect(conn.conn, nil, 0); retval != C.CS_SUCCEED {
 		conn.Close()
 		return nil, makeError(retval, "C.ct_connect failed")

--- a/info.go
+++ b/info.go
@@ -14,6 +14,8 @@ import (
 type Info struct {
 	dsn.Info
 
+	AppName string `json:"appname" doc:"Application Name to transmit to ASE"`
+
 	Userstorekey string `json:"key" multiref:"userstorekey" doc:"Key of userstore data to use for login"`
 
 	TLSHostname string `json:"tls-hostname" doc:"Expected server TLS hostname to pass to C driver"`


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Adds `info.AppName`, similar to go-ase.

**Related issues**

#20 

**Tests**

- [x] make integration
