### PR TITLE
Fix errors when closing a row early

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -135,5 +135,6 @@ func TestBit(t *testing.T) { integration.DoTestBit(t) }
 func TestImage(t *testing.T) { integration.DoTestImage(t) }
 
 // Routines
-func TestSQLTx(t *testing.T)   { integration.DoTestSQLTx(t) }
-func TestSQLExec(t *testing.T) { integration.DoTestSQLExec(t) }
+func TestSQLTx(t *testing.T)       { integration.DoTestSQLTx(t) }
+func TestSQLExec(t *testing.T)     { integration.DoTestSQLExec(t) }
+func TestSQLQueryRow(t *testing.T) { integration.DoTestSQLQueryRow(t) }

--- a/rows.go
+++ b/rows.go
@@ -10,7 +10,6 @@ package ase
 //#include "bridge.h"
 import "C"
 import (
-	"context"
 	"database/sql/driver"
 	"encoding/binary"
 	"fmt"
@@ -127,13 +126,9 @@ func (rows *Rows) Close() error {
 		}
 	}
 
-	newRows, _, err := rows.cmd.ConsumeResponse(context.Background())
-	if err != nil {
-		return err
-	}
-
-	if newRows != nil {
-		newRows.Close()
+	retval := C.ct_cancel(nil, rows.cmd.cmd, C.CS_CANCEL_ALL)
+	if retval != C.CS_SUCCEED {
+		return makeError(retval, "error cancelling command")
 	}
 
 	if !rows.cmd.isDynamic {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Prevents a spurious error on `db.QueryRow(...).Scan(..)` calls due to database/sql returning the error from `rows.Close` instead of from `Scan` by cancelling the remaining command instead of consuming the results.

Depends on https://github.com/SAP/go-dblib/pull/29

**Related issues**

https://github.com/SAP/cgo-ase/issues/19

**Tests**

- [x] make integration
