### PR TITLE
Adjust Copyright header in go.sum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,6 @@ else
 	$(GO) generate ./$(TARGET)
 	reuse addheader $(REUSE_ARGS) $(shell find ./$(TARGET) -type f -not -path '*/.git/*')
 endif
-	# go generate will also rebuild the go.sum and remove the
-	# header. Since generate only targets generated files and
-	# licenses the go.sum modification can be reverted.
-	[ -d .git ] && git checkout -- go.sum
 
 integration:
 	$(GO) test -race -cover ./... --tags=integration

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2021 SAP SE
-#
-# SPDX-License-Identifier: Apache-2.0
 github.com/SAP/go-dblib v0.0.0-20210215075453-57f65d7cdfe6 h1:4Fw0Cqyrl5xD98L+0lSdqZfPWnR09kQGx2wE6V0S3SY=
 github.com/SAP/go-dblib v0.0.0-20210215075453-57f65d7cdfe6/go.mod h1:+J5fa7eSdQ3ig2CqOarENCW3L2vPdDF+hl0N5h5pXOU=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=

--- a/go.sum.license
+++ b/go.sum.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 SAP SE
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Since the new [reuse-release](https://github.com/fsfe/reuse-tool/releases/tag/v0.13.0) the Copyright-header is handled differently for so called `UncommentableCommentStyle`-files (see this [issue](https://github.com/fsfe/reuse-tool/issues/189) or this [PR](https://github.com/fsfe/reuse-tool/pull/298)). This implies some some adjustments for `go.sum`. 

Since `go.sum` is automatically generated there was already a workaround in the `Makefile` to reset the Copyright-Header deletion (caused by `go generate ./...`/`make`-target `generate`). However, to include/reference a Copyright-Header to the `go.sum`-file another workaround of the `reuse`-tool is used by creating a `go.sum.license`-file.
