### PR TITLE
Update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ module github.com/SAP/cgo-ase
 go 1.15
 
 require (
-	github.com/SAP/go-dblib v0.0.0-20210215075453-57f65d7cdfe6
+	github.com/SAP/go-dblib v0.0.0-20210811145943-b072f542367d
 	github.com/spf13/pflag v0.0.0-20170417173400-9e4c21054fa1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/SAP/go-dblib v0.0.0-20210215075453-57f65d7cdfe6 h1:4Fw0Cqyrl5xD98L+0lSdqZfPWnR09kQGx2wE6V0S3SY=
-github.com/SAP/go-dblib v0.0.0-20210215075453-57f65d7cdfe6/go.mod h1:+J5fa7eSdQ3ig2CqOarENCW3L2vPdDF+hl0N5h5pXOU=
+github.com/SAP/go-dblib v0.0.0-20210811145943-b072f542367d h1:Z7LmRRsqc5ok98vdyGRjilmJRqdxZHf5RiotllTt6lA=
+github.com/SAP/go-dblib v0.0.0-20210811145943-b072f542367d/go.mod h1:AGxjWaOfTJ5lYqUrh6lhckiB/kr1W6xEYDefcPQhb1g=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
@@ -7,8 +7,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
-github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/spf13/pflag v0.0.0-20170417173400-9e4c21054fa1 h1:7bozMfSdo41n2NOc0GsVTTVUiA+Ncaj6pXNpm4UHKys=
 github.com/spf13/pflag v0.0.0-20170417173400-9e4c21054fa1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 h1:YTzHMGlqJu67/uEo1lBv0n3wBXhXNeUbB1XfN2vmTm0=


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

`make integration` failed due to an outdated dependency to `go-dblib`. Therefore, the dependencies in `go.mod` and `go.sum` are updated.

**Tests**

- [x] make integration
